### PR TITLE
성분 테이블 적용, Product ID 에 UUID가 아닌 정수형 hashcode 적용

### DIFF
--- a/backend/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/backend/src/main/java/org/mtvs/backend/product/controller/ProductController.java
+++ b/backend/src/main/java/org/mtvs/backend/product/controller/ProductController.java
@@ -2,11 +2,15 @@ package org.mtvs.backend.product.controller;
 
 import org.mtvs.backend.product.dto.ProductDTO;
 import org.mtvs.backend.product.entity.Product;
+import org.mtvs.backend.product.entity.Ingredient;
 import org.mtvs.backend.product.service.ProductService;
+import org.mtvs.backend.product.service.IngredientService;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,9 +20,11 @@ import java.util.List;
 public class ProductController {
 
     private final ProductService productService;
+    private final IngredientService ingredientService;
 
-    public ProductController(ProductService productService) {
+    public ProductController(ProductService productService, IngredientService ingredientService) {
         this.productService = productService;
+        this.ingredientService = ingredientService;
     }
 
     @GetMapping("/search/products")
@@ -33,5 +39,42 @@ public class ProductController {
         };
 
         return productList;
+    }
+    
+    // Dedicated ingredient search endpoint
+    @GetMapping("/search/ingredient")
+    public ResponseEntity<List<ProductDTO>> searchByIngredient(@RequestParam String koreanName) {
+        List<ProductDTO> products = productService.searchAllByIngredient(koreanName);
+        return ResponseEntity.ok(products);
+    }
+    
+    // Get all ingredients
+    @GetMapping("/ingredients")
+    public ResponseEntity<List<Ingredient>> getAllIngredients() {
+        List<Ingredient> ingredients = ingredientService.findAll();
+        return ResponseEntity.ok(ingredients);
+    }
+    
+    // Get ingredient by ID
+    @GetMapping("/ingredients/{id}")
+    public ResponseEntity<Ingredient> getIngredientById(@PathVariable Integer id) {
+        Ingredient ingredient = ingredientService.findById(id);
+        if (ingredient != null) {
+            return ResponseEntity.ok(ingredient);
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+    
+    // Get products by ingredient ID
+    @GetMapping("/ingredients/{id}/products")
+    public ResponseEntity<List<ProductDTO>> getProductsByIngredientId(@PathVariable Integer id) {
+        Ingredient ingredient = ingredientService.findById(id);
+        if (ingredient == null) {
+            return ResponseEntity.notFound().build();
+        }
+        
+        List<ProductDTO> products = productService.searchAllByIngredient(ingredient.getKoreanName());
+        return ResponseEntity.ok(products);
     }
 }

--- a/backend/src/main/java/org/mtvs/backend/product/dto/ProductDTO.java
+++ b/backend/src/main/java/org/mtvs/backend/product/dto/ProductDTO.java
@@ -6,9 +6,13 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.mtvs.backend.product.entity.Product;
 import org.mtvs.backend.product.service.FormulationService;
+import org.mtvs.backend.product.service.IngredientService;
+import org.mtvs.backend.product.entity.Ingredient;
 import org.mtvs.backend.user.entity.User;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 @NoArgsConstructor
 @Getter
@@ -39,7 +43,30 @@ public class ProductDTO {
                 product.getFormulationId(),
                 formulationService.getEnglishNameById(product.getFormulationId()),
                 product.getRecommendedType(),
-                product.getIngredients(),
+                new ArrayList<>(), // ingredients will be resolved separately if needed
+                product.getProductName(),
+                product.getImageUrl()
+        );
+    }
+    
+    // 엔티티에서 DTO로 변환 (ingredient names 포함)
+    public static ProductDTO fromEntity(Product product, FormulationService formulationService, IngredientService ingredientService) {
+        List<String> ingredientNames = new ArrayList<>();
+        List<Integer> ingredientIds = product.getIngredientIds();
+        
+        for (Integer id : ingredientIds) {
+            Ingredient ingredient = ingredientService.findById(id);
+            if (ingredient != null) {
+                ingredientNames.add(ingredient.getKoreanName());
+            }
+        }
+        
+        return new ProductDTO(
+                product.getId(),
+                product.getFormulationId(),
+                formulationService.getEnglishNameById(product.getFormulationId()),
+                product.getRecommendedType(),
+                ingredientNames,
                 product.getProductName(),
                 product.getImageUrl()
         );
@@ -53,19 +80,19 @@ public class ProductDTO {
                 product.getFormulationId(),
                 null, // formulation will be null - use the version with FormulationService
                 product.getRecommendedType(),
-                product.getIngredients(),
+                new ArrayList<>(), // ingredients will be empty - use the version with IngredientService
                 product.getProductName(),
                 product.getImageUrl()
         );
     }
 
-    // DTO 에서 엔티티로 변환
+    // DTO 에서 엔티티로 변환 (ingredient names는 별도 처리 필요)
     public Product toEntity() {
         Product product = new Product();
         product.setId(this.id);
         product.setFormulationId(this.formulationId);
         product.setRecommendedType(this.recommendedType);
-        product.setIngredients(this.ingredients);
+        // Note: ingredients are handled separately through IngredientService
         product.setProductName(this.productName);
         product.setImageUrl(this.imageUrl);
         return product;

--- a/backend/src/main/java/org/mtvs/backend/product/dto/ProductDTO.java
+++ b/backend/src/main/java/org/mtvs/backend/product/dto/ProductDTO.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 @Getter
 @Setter
 public class ProductDTO {
-    private String id;
+    private Integer id;
     private Byte formulationId;
     private String formulation; // Add string formulation field for frontend compatibility
     private Byte recommendedType;
@@ -26,7 +26,7 @@ public class ProductDTO {
     private String productName;
     private String imageUrl;
 
-    public ProductDTO(String id, Byte formulationId, String formulation, Byte recommendedType, List<String> ingredients, String productName, String imageUrl) {
+    public ProductDTO(Integer id, Byte formulationId, String formulation, Byte recommendedType, List<String> ingredients, String productName, String imageUrl) {
         this.id = id;
         this.formulationId = formulationId;
         this.formulation = formulation;
@@ -89,11 +89,9 @@ public class ProductDTO {
     // DTO 에서 엔티티로 변환 (ingredient names는 별도 처리 필요)
     public Product toEntity() {
         Product product = new Product();
-        product.setId(this.id);
         product.setFormulationId(this.formulationId);
         product.setRecommendedType(this.recommendedType);
-        // Note: ingredients are handled separately through IngredientService
-        product.setProductName(this.productName);
+        product.setProductName(this.productName); // sets id via setter
         product.setImageUrl(this.imageUrl);
         return product;
     }

--- a/backend/src/main/java/org/mtvs/backend/product/dto/ProductWithImageDTO.java
+++ b/backend/src/main/java/org/mtvs/backend/product/dto/ProductWithImageDTO.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Getter
 @Setter
 public class ProductWithImageDTO {
-    private String id;
+    private Integer id;
     private Byte formulationId;
     private List<String> ingredients;
     private String recommendedType;

--- a/backend/src/main/java/org/mtvs/backend/product/entity/Ingredient.java
+++ b/backend/src/main/java/org/mtvs/backend/product/entity/Ingredient.java
@@ -1,0 +1,30 @@
+package org.mtvs.backend.product.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "ingredients")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Ingredient {
+    @Id
+    private Integer id; // Hash of korean_name
+    
+    @Column(name = "korean_name", nullable = false)
+    private String koreanName;
+    
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+    
+    // Constructor for creating new ingredients
+    public Ingredient(Integer id, String koreanName) {
+        this.id = id;
+        this.koreanName = koreanName;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/org/mtvs/backend/product/entity/Product.java
+++ b/backend/src/main/java/org/mtvs/backend/product/entity/Product.java
@@ -4,8 +4,6 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 import org.mtvs.backend.global.entity.BaseEntity;
 
 import java.util.ArrayList;
@@ -21,8 +19,8 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class Product extends BaseEntity{
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private String id;
+    private Integer id;
+
     @Column(name = "formulation_id")
     private Byte formulationId;
 
@@ -46,6 +44,26 @@ public class Product extends BaseEntity{
 
     @Column(name = "product_name")
     private String productName;
+    
+    public void setProductName(String productName) {
+        this.productName = productName;
+        if (productName != null) {
+            this.id = productName.hashCode();
+        }
+    }
+
+    // Custom constructor to ensure id is always set from productName
+    public Product(String productName) {
+        this.productName = productName;
+        if (productName != null) {
+            this.id = productName.hashCode();
+        }
+    }
+
+    // Make setId private to prevent accidental manual setting
+    private void setId(Integer id) {
+        this.id = id;
+    }
 
     @Column(name = "image_url")
     private String imageUrl;

--- a/backend/src/main/java/org/mtvs/backend/product/entity/Product.java
+++ b/backend/src/main/java/org/mtvs/backend/product/entity/Product.java
@@ -26,9 +26,20 @@ public class Product extends BaseEntity{
     @Column(name = "formulation_id")
     private Byte formulationId;
 
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "ingredients", columnDefinition = "jsonb")
-    private List<String> ingredients;
+    @Column(name = "ingredient_id_1")
+    private Integer ingredientId1;
+
+    @Column(name = "ingredient_id_2")
+    private Integer ingredientId2;
+
+    @Column(name = "ingredient_id_3")
+    private Integer ingredientId3;
+
+    @Column(name = "ingredient_id_4")
+    private Integer ingredientId4;
+
+    @Column(name = "ingredient_id_5")
+    private Integer ingredientId5;
 
     @Column(name = "recommended_type")
     private Byte recommendedType;
@@ -92,5 +103,50 @@ public class Product extends BaseEntity{
         List<Byte> current = getConcernIds();
         current.remove(concernId);
         setConcerns(current.toArray(new Byte[0]));
+    }
+
+    // Ingredient helper methods
+    public void setIngredientIds(Integer... ingredientIds) {
+        // Clear all first
+        this.ingredientId1 = null;
+        this.ingredientId2 = null;
+        this.ingredientId3 = null;
+        this.ingredientId4 = null;
+        this.ingredientId5 = null;
+        
+        // Assign in order (max 5)
+        for (int i = 0; i < Math.min(ingredientIds.length, 5); i++) {
+            switch(i) {
+                case 0: this.ingredientId1 = ingredientIds[i]; break;
+                case 1: this.ingredientId2 = ingredientIds[i]; break;
+                case 2: this.ingredientId3 = ingredientIds[i]; break;
+                case 3: this.ingredientId4 = ingredientIds[i]; break;
+                case 4: this.ingredientId5 = ingredientIds[i]; break;
+            }
+        }
+    }
+    
+    public List<Integer> getIngredientIds() {
+        List<Integer> ids = new ArrayList<>();
+        if (ingredientId1 != null) ids.add(ingredientId1);
+        if (ingredientId2 != null) ids.add(ingredientId2);
+        if (ingredientId3 != null) ids.add(ingredientId3);
+        if (ingredientId4 != null) ids.add(ingredientId4);
+        if (ingredientId5 != null) ids.add(ingredientId5);
+        return ids;
+    }
+    
+    public void addIngredientId(Integer ingredientId) {
+        List<Integer> current = getIngredientIds();
+        if (!current.contains(ingredientId) && current.size() < 5) {
+            current.add(ingredientId);
+            setIngredientIds(current.toArray(new Integer[0]));
+        }
+    }
+    
+    public void removeIngredientId(Integer ingredientId) {
+        List<Integer> current = getIngredientIds();
+        current.remove(ingredientId);
+        setIngredientIds(current.toArray(new Integer[0]));
     }
 }

--- a/backend/src/main/java/org/mtvs/backend/product/entity/ProductUserLink.java
+++ b/backend/src/main/java/org/mtvs/backend/product/entity/ProductUserLink.java
@@ -3,9 +3,11 @@ package org.mtvs.backend.product.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.mtvs.backend.user.entity.User;
 
+@Data
 @Table(name = "product_user_link")
 @Entity
 @IdClass(ProductUserLinkId.class)
@@ -15,7 +17,7 @@ public class ProductUserLink {
 
     @Id
     @Column(name = "product_id")
-    private String productId;
+    private Integer productId;
 
     @Id
     @Column(name = "user_id")
@@ -29,35 +31,4 @@ public class ProductUserLink {
     @JoinColumn(name = "user_id", insertable = false, updatable = false)
     private User user;
 
-    public String getProductId() {
-        return productId;
-    }
-
-    public void setProductId(String productId) {
-        this.productId = productId;
-    }
-
-    public String getUserId() {
-        return userId;
-    }
-
-    public void setUserId(String userId) {
-        this.userId = userId;
-    }
-
-    public Product getProduct() {
-        return product;
-    }
-
-    public void setProduct(Product product) {
-        this.product = product;
-    }
-
-    public User getUser() {
-        return user;
-    }
-
-    public void setUser(User user) {
-        this.user = user;
-    }
 }

--- a/backend/src/main/java/org/mtvs/backend/product/entity/ProductUserLinkId.java
+++ b/backend/src/main/java/org/mtvs/backend/product/entity/ProductUserLinkId.java
@@ -7,12 +7,12 @@ import java.io.Serializable;
 import java.util.Objects;
 
 public class ProductUserLinkId implements Serializable {
-    private String productId;
+    private Integer productId;
     private String userId;
 
     public ProductUserLinkId() {}
 
-    public ProductUserLinkId(String productId, String userId) {
+    public ProductUserLinkId(Integer productId, String userId) {
         this.productId = productId;
         this.userId = userId;
     }

--- a/backend/src/main/java/org/mtvs/backend/product/repository/IngredientRepository.java
+++ b/backend/src/main/java/org/mtvs/backend/product/repository/IngredientRepository.java
@@ -1,0 +1,12 @@
+package org.mtvs.backend.product.repository;
+
+import org.mtvs.backend.product.entity.Ingredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface IngredientRepository extends JpaRepository<Ingredient, Integer> {
+    Optional<Ingredient> findByKoreanName(String koreanName);
+}

--- a/backend/src/main/java/org/mtvs/backend/product/repository/ProductRepository.java
+++ b/backend/src/main/java/org/mtvs/backend/product/repository/ProductRepository.java
@@ -28,4 +28,25 @@ public interface ProductRepository extends JpaRepository<Product, String> {
 
 
     List<Product> findAllByImageUrl(String imageUrl);
+    
+    // Ingredient search methods
+    @Query("""
+        SELECT p FROM Product p 
+        WHERE p.ingredientId1 = :ingredientId 
+           OR p.ingredientId2 = :ingredientId 
+           OR p.ingredientId3 = :ingredientId 
+           OR p.ingredientId4 = :ingredientId 
+           OR p.ingredientId5 = :ingredientId
+        """)
+    List<Product> findByIngredientId(@Param("ingredientId") Integer ingredientId);
+    
+    @Query("""
+        SELECT DISTINCT p FROM Product p 
+        WHERE p.ingredientId1 IN :ingredientIds 
+           OR p.ingredientId2 IN :ingredientIds 
+           OR p.ingredientId3 IN :ingredientIds 
+           OR p.ingredientId4 IN :ingredientIds 
+           OR p.ingredientId5 IN :ingredientIds
+        """)
+    List<Product> findByAnyIngredientIds(@Param("ingredientIds") List<Integer> ingredientIds);
 }

--- a/backend/src/main/java/org/mtvs/backend/product/repository/ProductRepository.java
+++ b/backend/src/main/java/org/mtvs/backend/product/repository/ProductRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface ProductRepository extends JpaRepository<Product, String> {
+public interface ProductRepository extends JpaRepository<Product, Integer> {
 
     @Query("SELECT EXISTS (SELECT 1 FROM Product p WHERE p.productName = :productName AND p.imageUrl IS NOT NULL AND p.imageUrl != 'x' AND p.imageUrl != '')")
     boolean existsImageUrlByProductName(@Param("productName") String productName);
@@ -21,7 +21,7 @@ public interface ProductRepository extends JpaRepository<Product, String> {
 
 //    @Query("SELECT p FROM Product p WHERE p.productName LIKE %:query%")
 //    List<Product> findProductsByProductNameContaining(String query);
-    List<Product> findProductsById(String userId);
+    List<Product> findProductsById(Integer productId);
 //    List<Product> findByUserIdAndFormulationType(String userId, String formulationType);
 
     boolean existsProductByProductName(String productName);

--- a/backend/src/main/java/org/mtvs/backend/product/repository/ProductUserLinkRepository.java
+++ b/backend/src/main/java/org/mtvs/backend/product/repository/ProductUserLinkRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ProductUserLinkRepository extends JpaRepository<ProductUserLink, ProductUserLinkId> {
-    boolean existsByProductIdAndUserId(String productId, String userId);
+    boolean existsByProductIdAndUserId(Integer productId, String userId);
 
     List<ProductUserLink> findByUserId(String userId);
 }

--- a/backend/src/main/java/org/mtvs/backend/product/service/IngredientService.java
+++ b/backend/src/main/java/org/mtvs/backend/product/service/IngredientService.java
@@ -1,0 +1,54 @@
+package org.mtvs.backend.product.service;
+
+import org.mtvs.backend.product.entity.Ingredient;
+import org.mtvs.backend.product.repository.IngredientRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@Transactional
+public class IngredientService {
+    
+    private final IngredientRepository ingredientRepository;
+    
+    public IngredientService(IngredientRepository ingredientRepository) {
+        this.ingredientRepository = ingredientRepository;
+    }
+    
+    public Set<Integer> resolveIngredientIds(List<String> koreanNames) {
+        Set<Integer> ids = new HashSet<>();
+        
+        for (String name : koreanNames) {
+            Integer id = hashIngredient(name);
+            
+            if (!ingredientRepository.existsById(id)) {
+                Ingredient ingredient = new Ingredient(id, name);
+                ingredientRepository.save(ingredient);
+            }
+            
+            ids.add(id);
+        }
+        
+        return ids;
+    }
+    
+    public Integer hashIngredient(String korean) {
+        return korean.trim()
+                    .replaceAll("\\s+", "")
+                    .toLowerCase()
+                    .hashCode();
+    }
+    
+    public Ingredient findById(Integer id) {
+        return ingredientRepository.findById(id).orElse(null);
+    }
+    
+    public List<Ingredient> findAll() {
+        return ingredientRepository.findAll();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
       maximum-pool-size: 2
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: false
     properties:
       hibernate:


### PR DESCRIPTION
성분 테이블을 분리하여 
1개 Product 당 5개의 주요 성분을 (3개 가능) 정수형 ID 로 입력 하도록 하였습니다.

성분 테이블의 성분명 한국어 - 를 java hashcode 로 변환하여 정수형으로 바꾼 후 id 로 활용합니다.

마찬가지로 Product 도 hashcode 를 id 로 활용합니다. 4조개 Product 종류 입력 가능